### PR TITLE
Fix reaction mapping id type mismatch

### DIFF
--- a/synthemol/reactions/utils.py
+++ b/synthemol/reactions/utils.py
@@ -46,17 +46,30 @@ def load_and_set_allowed_reaction_building_blocks(
         chemical_spaces, reaction_to_building_blocks_paths
     ):
         with open(reaction_to_building_blocks_path, "rb") as f:
-            chemical_space_to_reaction_to_reactant_to_building_blocks[
-                chemical_space
-            ] = pickle.load(f)
+            reaction_to_reactant_to_building_blocks = pickle.load(f)
+
+        # Ensure reaction IDs are strings to match ``Reaction.id``
+        chemical_space_to_reaction_to_reactant_to_building_blocks[
+            chemical_space
+        ] = {
+            str(reaction_id): reactant_to_bbs
+            for reaction_id, reactant_to_bbs in reaction_to_reactant_to_building_blocks.items()
+        }
 
     # Set allowed building blocks for each reactant in each reaction
     for reaction in reactions:
         for reactant_index, reactant in enumerate(reaction.reactants):
-            reactant.allowed_building_blocks = chemical_space_to_reaction_to_reactant_to_building_blocks[
-                reaction.chemical_space
-            ][
-                reaction.id
-            ][
-                reactant_index
-            ]
+            try:
+                reactant.allowed_building_blocks = chemical_space_to_reaction_to_reactant_to_building_blocks[
+                    reaction.chemical_space
+                ][
+                    reaction.id
+                ][
+                    reactant_index
+                ]
+            except KeyError as e:
+                raise KeyError(
+                    f"Missing key: {reaction.id} in chemical space '{reaction.chemical_space}'"
+                    " \u2014 check that your reaction IDs match in type (str vs int) between"
+                    " source data and .pkl mapping."
+                ) from e


### PR DESCRIPTION
## Summary
- convert reaction ID keys to strings when loading allowed building block mappings
- add helpful error if a reaction id cannot be found due to type mismatch

## Testing
- `python -m py_compile synthemol/reactions/utils.py`

------
https://chatgpt.com/codex/tasks/task_b_686c05688e708320bd5e99305dc60525